### PR TITLE
docs: rg-full-auto v6.0 'super full auto' design + parked v5 PRD

### DIFF
--- a/rg-full-auto/docs/plans/2026-05-13-v5-portability-deferred.md
+++ b/rg-full-auto/docs/plans/2026-05-13-v5-portability-deferred.md
@@ -1,0 +1,560 @@
+# PRD: rg-full-auto v5.0 — Environment-Aware Autonomous Onboarding
+
+**Version:** 0.1 (Draft)
+**Date:** 2026-02-19
+**Author:** scottybe + claude
+**Status:** RFC — Requesting Comments
+
+---
+
+## 1. Problem Statement
+
+### What Exists Today (v4.0)
+
+rg-full-auto v4.0 introduced batch-first processing, per-item state machines, and autonomous decision-making. The architecture is sound but has critical gaps:
+
+1. **Hardcoded to local Mac** — All paths assume `/Users/scottybe/`, all binary ops assume osascript, all Chrome automation assumes local browser. The skill cannot run in Claude Code on the web (Cowork), cloud containers, or Windows.
+
+2. **Tests are broken** — Existing integration tests (`test_rg_full_auto_catalog_fallback.py`) reference the v3.x API (`RGItemProcessor(interactive=False)`, `processor.phase3_catalog()`). No tests exist for the v4.0 state machine, queue manager, or batch orchestrator.
+
+3. **Trigger mechanism is manual** — User must explicitly say "onboard these" or run a CLI command. No automated polling for new photos, no watch-and-start capability.
+
+4. **Claude environment blindness** — The skill doesn't detect which Claude environment it's running in (Code CLI on Mac, Code on web/Cowork, cloud container) and can't adapt its behavior accordingly.
+
+5. **Phases can't degrade gracefully** — If osascript isn't available (Cowork/cloud), ALL Mac-dependent phases fail rather than doing what they can and deferring what they can't.
+
+### What We Want (v5.0)
+
+A single `rg-full-auto` skill that:
+- **Detects its runtime environment** and adapts phase execution accordingly
+- **Runs everywhere Claude runs** — local Mac, Cowork, cloud, Windows (future)
+- **Polls for work** via Photos.app clustering (local) OR user prompt (everywhere)
+- **Degrades gracefully** — does API-portable phases in cloud, defers Mac-only phases
+- **Has passing tests** for state machine, queue, batch orchestrator, and phase logic
+- **Communicates appropriately** — interactive chat in Cowork, structured output in Code CLI
+
+---
+
+## 2. Environments & Capabilities
+
+### 2.1 Environment Matrix
+
+| Environment | Description | Filesystem | osascript | Square API | Chrome MCP | Photos.app | Git Push |
+|-------------|------------|-----------|-----------|-----------|-----------|-----------|---------|
+| **Code CLI (Mac)** | Terminal on user's Mac | Full | Yes | Yes (via MCP or `~/.env`) | Yes | Yes | Yes |
+| **Code CLI (Linux/Win)** | Terminal on non-Mac | Full (local) | No | Yes (if token set) | Possible | No | Yes |
+| **Cowork (Web)** | Claude web chat, collaborative | Sandboxed | No | Yes (if MCP configured) | No | No | No (unless git MCP) |
+| **Cloud Container** | Headless Claude agent | `/mnt/` only | No | Yes (if token injected) | No | No | Possible via API |
+
+### 2.2 Capability Detection
+
+At skill invocation time, detect available capabilities:
+
+```python
+class RuntimeCapabilities:
+    has_osascript: bool       # Can run AppleScript (macOS only)
+    has_filesystem: bool      # Can read/write user's local files
+    has_square_mcp: bool      # Square MCP server connected
+    has_square_token: bool    # SQUARE_ACCESS_TOKEN available
+    has_chrome_mcp: bool      # Chrome/browser MCP tools available
+    has_photos_db: bool       # Photos.app SQLite accessible
+    has_git: bool             # Git available for push operations
+    has_removebg: bool        # REMOVEBG_API_KEY available
+    has_image_api: bool       # Any image processing API available
+    environment: str          # "mac_cli" | "linux_cli" | "cowork" | "cloud"
+    interaction_mode: str     # "cli" (structured) | "chat" (conversational)
+```
+
+**Detection method:** Python probe script (`scripts/detect_env.py`) that tests each capability and outputs JSON. Claude reads the output and adapts.
+
+### 2.3 Phase Portability Classification
+
+| Phase | Portable? | Mac-Only Operations | Cloud Alternative |
+|-------|-----------|--------------------|--------------------|
+| **0: Image Processing** | Partial | `sips` compression, HEIC conversion, Photos.app cluster | User provides image directly; skip compression if under limit |
+| **1: Appraisal** | Yes | None (Claude's own reasoning) | Fully portable |
+| **2: Catalog Creation** | Yes | None (Square API) | Fully portable via MCP or direct API |
+| **3: Inventory** | Yes | None (Square API) | Fully portable |
+| **4: Image Upload** | Partial | osascript script execution | Direct API call with `requests` if token available |
+| **5: Payment Link** | Yes | None (Square API) | Fully portable |
+| **6: Label** | Partial | Writes to local CSV | Generate CSV content, defer file write |
+| **7: Publishing** | Partial | Git push, HTML file write | Generate HTML content, defer git push (or use GitHub API) |
+| **8: Whatnot** | No | Chrome automation required | Defer entirely — queue for local execution |
+| **9: Photos Archive** | No | Photos.app required | Skip — not applicable outside Mac |
+
+---
+
+## 3. Architecture
+
+### 3.1 Layered Execution Model
+
+```
+┌──────────────────────────────────────────────────┐
+│  SKILL.md (Claude's Instructions)                │  Layer 1: Skill definition
+│  - Phase descriptions, decision matrix           │  (always loaded)
+│  - Environment-aware branching rules             │
+└──────────────────────────────────────────────────┘
+         │
+         ▼
+┌──────────────────────────────────────────────────┐
+│  State Machine (item_state.py)                   │  Layer 2: Orchestration
+│  - Phase dependencies, transitions               │  (environment-agnostic)
+│  - Question queue, decision log                  │
+│  Batch Orchestrator (process_batch.py)           │
+│  - Multi-item loop, isolation, summary           │
+│  Queue Manager (onboarding_queue.py)             │
+│  - Centralized status, sync                      │
+└──────────────────────────────────────────────────┘
+         │
+         ▼
+┌──────────────────────────────────────────────────┐
+│  Phase Executors                                 │  Layer 3: Execution
+│  ┌─────────────────┐  ┌──────────────────────┐  │  (environment-specific)
+│  │ Claude-Executed  │  │ Script-Executed       │  │
+│  │ (MCP + osascript │  │ (Python with API     │  │
+│  │  when available) │  │  keys when available)│  │
+│  └─────────────────┘  └──────────────────────┘  │
+│  ┌─────────────────────────────────────────────┐ │
+│  │ Deferred Queue (for env-unavailable phases) │ │
+│  │ - Captures intent + data                    │ │
+│  │ - Executes when capability becomes available│ │
+│  └─────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────┘
+```
+
+### 3.2 State Architecture (Unchanged from v4.0 — Proven Design)
+
+```
+Per-Item State:
+  items/RG-XXXX/.state.json
+  - Phase statuses, outputs, questions, decisions
+
+Centralized Queue:
+  ops/inventory/onboarding-queue.json
+  - Dashboard view, batch summaries, blocked items
+
+Deferred Actions (NEW):
+  ops/inventory/deferred-actions.json
+  - Phase executions that require a different environment
+  - Picked up when user returns to a capable environment
+```
+
+### 3.3 Deferred Action Model (NEW)
+
+When a phase can't execute in the current environment but the work is well-defined:
+
+```json
+{
+  "action_id": "def-001",
+  "sku": "RG-0015",
+  "phase": "phase_8_whatnot",
+  "requires": ["chrome_mcp"],
+  "payload": {
+    "csv_row": "...",
+    "category": "Glassware > Vintage",
+    "shipping_profile": "Standard"
+  },
+  "created_at": "2026-02-19T14:30:00Z",
+  "created_in": "cowork",
+  "status": "pending"
+}
+```
+
+When user opens Code CLI on Mac: "You have 3 deferred actions from your Cowork session. Run them now?"
+
+---
+
+## 4. Trigger & Intake Mechanisms
+
+### 4.1 Trigger Matrix
+
+| Trigger | Environment | How It Works |
+|---------|-------------|-------------|
+| **Photos.app polling** | Mac CLI only | `find_product_clusters.py` detects new photo groups in last N days. If new clusters found, prompt: "Found 3 new product photo sets. Onboard?" |
+| **User prompt** | All | "onboard these", "new item", "sell this", etc. — existing keyword triggers |
+| **Photo dump** | Mac CLI, Cowork | User drops/uploads photos. 1 photo = 1 item. |
+| **CLI command** | Mac CLI, Linux CLI | `process_batch.py --photos ...` or `--resume` |
+| **Deferred resume** | Mac CLI | On session start, check for deferred actions from cloud/Cowork |
+
+### 4.2 Photos.app Polling (Local Mac Only)
+
+**Concept:** Instead of requiring the user to explicitly drop photos, the agent can proactively discover new product photo clusters.
+
+**Implementation:**
+
+```python
+# In SKILL.md startup section:
+# "If running on Mac CLI, check for new product photo clusters first"
+
+# Step 1: Run cluster detection
+find_product_clusters.py --days 7 --type product --json
+
+# Step 2: Compare against known SKUs (items already onboarded)
+# Filter out clusters whose photos are already in RG-XXXX folders
+
+# Step 3: If new clusters found, present to user:
+# "I found 3 new product photo sets from the last week:
+#   - Cluster A: 4 photos (brass lamp, shot 2 days ago)
+#   - Cluster B: 2 photos (ceramic vase, shot yesterday)
+#   - Cluster C: 1 photo (vintage book, shot today)
+#  Start onboarding? [all / pick / skip]"
+```
+
+**Polling is NOT a background daemon.** It runs at conversation start or when the user invokes the skill. "Polling" = checking on each invocation, not a persistent watcher.
+
+### 4.3 Prompt-Based Intake (All Environments)
+
+For Cowork/cloud where Photos.app isn't available:
+
+```
+User: "I have 5 new items to onboard"
+Claude: "Drop the photos here or describe them. I'll start processing each one."
+
+User: [uploads 5 images]
+Claude: Assigns SKUs, starts pipeline for each. Reports progress and questions.
+```
+
+For Cowork specifically, the interaction should be **conversational**:
+- Progress updates inline with chat
+- Questions asked naturally ("This looks like a ceramic vase — am I right?")
+- Decisions explained conversationally
+- Summary at end with links and deferred actions
+
+---
+
+## 5. Communication Patterns
+
+### 5.1 By Environment
+
+| Environment | Style | Progress | Questions | Summary |
+|-------------|-------|----------|-----------|---------|
+| **Code CLI** | Structured, phase-by-phase | `[RG-0015] Phase 2 -> DONE` | Batch at end (queue & continue) | Table format |
+| **Cowork** | Conversational, inline | "Working on the brass lamp... catalog created, now uploading image..." | Asked inline as they arise | Narrative with links |
+| **Cloud** | JSON-structured | Machine-readable events | Queued in state file | JSON summary |
+
+### 5.2 Cowork-Specific Behavior
+
+Cowork is the most interactive environment. The agent should:
+
+1. **Narrate progress** — "I'm looking at your first photo. Looks like a mid-century ceramic planter. Condition seems good — minor glaze crazing but no chips. I'm pricing it at $35 based on comps."
+2. **Ask naturally** — "I can't tell from the photo — is this set a matching pair, or two different items?"
+3. **Show work** — "Here's what I'm listing on Square: [details]. Sound right?"
+4. **Defer gracefully** — "I've done everything I can from here. When you're on your Mac, I'll need to: upload the hero image, push to GitHub Pages, and list on Whatnot. I've saved all the prep work."
+
+### 5.3 Question Priority
+
+Even in autonomous mode, some questions genuinely need human input. Priority levels:
+
+| Priority | Example | Behavior |
+|----------|---------|----------|
+| **P0: Blocking** | "Can't identify item from photo" | Park immediately, ask user |
+| **P1: Important** | "Is this a set or individual items?" | Make best guess, flag for review |
+| **P2: Nice-to-have** | "Any provenance or history?" | Skip, proceed with available info |
+| **P3: Cosmetic** | "Preferred title wording?" | Agent decides, user reviews post-onboard |
+
+---
+
+## 6. Phase Execution Spec
+
+### 6.0 Environment Probe (NEW — Runs First)
+
+Before any phase executes, detect capabilities:
+
+```
+detect_env.py → {
+  "environment": "mac_cli",
+  "has_osascript": true,
+  "has_square_mcp": true,
+  "has_chrome_mcp": true,
+  "has_photos_db": true,
+  "has_git": true,
+  "has_removebg": true,
+  "interaction_mode": "cli"
+}
+```
+
+Store result in `.state.json` → `runtime_context`. Phase executors read this to branch.
+
+### 6.1 Phase 0: Image Processing
+
+**Mac CLI:** Full pipeline — Photos.app cluster → copy → compress → remove background
+**Cowork:** User uploads image → store in staging → remove background via API (if API key available) → else use raw image
+**Cloud:** Image provided via upload → process via API
+
+**Key change:** Background removal uses `image-processor` skill's model routing, which already supports multiple APIs (Nano Banana, Gemini, remove.bg). The portable path uses these APIs directly via `requests`, bypassing osascript.
+
+### 6.2 Phase 1: Appraisal (Fully Portable)
+
+No changes needed. Claude's reasoning works identically in all environments.
+
+### 6.3 Phases 2-3: Catalog + Inventory (Fully Portable)
+
+Square API calls via MCP (`mcp_square_api`) or direct HTTP. Both work in all environments where the token is available.
+
+**Adaptation:** If `has_square_mcp` → use MCP tools. If `has_square_token` but no MCP → use `requests` directly. If neither → defer to state file with full payload for later execution.
+
+### 6.4 Phase 4: Image Upload (Partially Portable)
+
+**Mac CLI:** osascript → `upload_image.py` (current path)
+**Other envs:** Direct `requests.post` multipart upload to Square Image API. The `upload_image.py` script's core logic is just a `requests` call — factor it out so it can run without osascript.
+
+### 6.5 Phase 5: Payment Link (Fully Portable)
+
+No changes needed. Square API.
+
+### 6.6 Phase 6: Label (Partially Portable)
+
+**Mac CLI:** Append to local CSV file
+**Other envs:** Generate CSV row content, store in `.state.json` outputs. Defer file write.
+
+### 6.7 Phase 7: Publishing (Partially Portable)
+
+**Mac CLI:** Write HTML, update gallery index, git commit & push
+**Other envs:**
+- Generate HTML content (portable)
+- Generate gallery card HTML snippet (portable)
+- Store generated content in `.state.json`
+- Defer git push (or use GitHub API if available)
+
+**GitHub API alternative:** For Cowork/cloud, could use `gh api` or GitHub's Contents API to commit files directly — no local git needed. This is a stretch goal.
+
+### 6.8 Phase 8: Whatnot (Mac-Only, Defer)
+
+**Mac CLI:** Full Chrome automation via MCP
+**Other envs:** Build CSV row + metadata payload, store as deferred action. Execute when Chrome MCP is available.
+
+### 6.9 Phase 9: Photos Archive (Mac-Only, Skip)
+
+**Mac CLI:** Archive to Photos.app albums
+**Other envs:** Skip entirely — not applicable. Mark as skipped with reason "Photos.app not available."
+
+---
+
+## 7. Test Strategy
+
+### 7.1 Current State (Broken)
+
+The existing test `test_rg_full_auto_catalog_fallback.py` references the v3.x API:
+- `RGItemProcessor(interactive=False)` — `interactive` param removed in v4.0
+- `processor.phase3_catalog()` — method renamed to `_phase_2()` in v4.0
+
+These tests must be updated to match the v4.0+ API.
+
+### 7.2 Test Plan
+
+```
+testing/
+├── unit/
+│   ├── test_item_state.py              # State machine transitions
+│   ├── test_onboarding_queue.py        # Queue CRUD, sync, question routing
+│   ├── test_detect_env.py              # Environment detection
+│   └── test_phase_portability.py       # Phase adaptation by environment
+├── integration/
+│   ├── test_batch_orchestrator.py      # Multi-item processing, isolation
+│   ├── test_process_new_item.py        # Single-item pipeline (mocked APIs)
+│   ├── test_catalog_fallback.py        # Square API fallback chain (updated)
+│   ├── test_deferred_actions.py        # Defer + resume lifecycle
+│   └── test_resume_across_sessions.py  # State persistence + resume
+└── conftest.py                         # Shared fixtures, mock factories
+```
+
+### 7.3 Unit Test Coverage Targets
+
+**item_state.py (State Machine):**
+- Phase transitions: pending → in_progress → completed/failed/blocked/skipped
+- Dependency resolution: `next_runnable_phase()` respects PHASE_DEPENDENCIES
+- Question lifecycle: block → answer → unblock
+- Status recalculation: item-level status derived from phase statuses
+- Serialization: to_dict() ↔ from_dict() round-trip
+- Decision logging: entries accumulate correctly
+
+**onboarding_queue.py (Queue Manager):**
+- Upsert: add new, update existing
+- Sync: rebuild from .state.json files
+- Blocked items report: collects questions across items
+- Answer routing: answer reaches correct item + phase
+
+**process_batch.py (Orchestrator):**
+- Ingestion: photo list → item states created
+- Isolation: one item failure doesn't stop others
+- Queue & continue: blocked item parked, others advance
+- Resume: previously-blocked items resume when answers provided
+- SKU allocation: sequential, no collisions
+
+### 7.4 Integration Test Coverage
+
+**Catalog fallback chain (update existing test):**
+- batchInsertObjects fails → upsertCatalogObject succeeds
+- Both fail → phase marked FAILED, other phases continue
+- ID extraction: from id_mappings, from object traversal
+
+**Deferred actions (new):**
+- Phase deferred in Cowork → picked up in Mac CLI
+- Multiple deferred actions across items → all executed
+- Deferred action fails → error captured, not lost
+
+### 7.5 What We DON'T Test
+
+- Live Square API calls (requires real credentials)
+- osascript execution (Mac-only, integration tested manually)
+- Chrome MCP automation (requires browser)
+- Photos.app access (requires Mac + Full Disk Access)
+
+These are tested via manual E2E runs, not automated tests.
+
+---
+
+## 8. Migration Path
+
+### 8.1 From v4.0 to v5.0
+
+**Non-breaking changes:**
+- Add `detect_env.py` script
+- Add `deferred_actions.py` module
+- Add environment branching in SKILL.md phase instructions
+- Update tests to v4.0+ API
+- Add new tests
+
+**Breaking changes:**
+- `process_new_item.py` phase methods need environment-aware branching
+- `process_batch.py` needs to handle deferred phases
+- SKILL.md phase instructions need cloud/Cowork paths
+
+### 8.2 Rollout Strategy
+
+1. **Phase A: Fix tests** — Update existing tests to v4.0 API, add unit tests for state machine + queue
+2. **Phase B: Add env detection** — `detect_env.py` + runtime_context in state
+3. **Phase C: Portable phases** — Add cloud execution paths for phases 1-5
+4. **Phase D: Deferred model** — Implement defer/resume for Mac-only phases
+5. **Phase E: Cowork communication** — Chat-style interaction for Cowork mode
+6. **Phase F: Photos polling** — Auto-detect new photo clusters at skill invocation
+
+Each phase is independently shippable and testable.
+
+---
+
+## 9. File Changes Summary
+
+### New Files
+| File | Purpose |
+|------|---------|
+| `scripts/detect_env.py` | Runtime capability detection |
+| `scripts/deferred_actions.py` | Defer/resume module for env-unavailable phases |
+| `testing/unit/test_item_state.py` | State machine unit tests |
+| `testing/unit/test_onboarding_queue.py` | Queue manager unit tests |
+| `testing/unit/test_detect_env.py` | Environment detection tests |
+| `testing/integration/test_batch_orchestrator.py` | Batch processing integration tests |
+| `testing/integration/test_deferred_actions.py` | Defer/resume integration tests |
+
+### Modified Files
+| File | Changes |
+|------|---------|
+| `SKILL.md` | v5.0 — add environment-aware phase instructions, Cowork communication patterns, Photos polling trigger, deferred actions documentation |
+| `scripts/process_new_item.py` | Add env-aware phase branching, portable API paths |
+| `scripts/process_batch.py` | Handle deferred phases, env-aware processing |
+| `scripts/item_state.py` | Add `runtime_context` field, deferred action tracking |
+| `scripts/onboarding_queue.py` | Add deferred actions collection, env field |
+| `ARCHITECTURE_AUDIT.md` | Update to v5.0 compliance check |
+| `testing/integration/test_rg_full_auto_catalog_fallback.py` | Update to v4.0+ API |
+
+### Unchanged Files
+| File | Why |
+|------|-----|
+| `scripts/remove_background.py` | Already delegates to image-processor |
+| `scripts/place_files.py` | Mac-only utility, still needed for Mac path |
+| `scripts/sync_to_whatnot.py` | Whatnot-specific, still needed for Mac path |
+| `references/*` | Reference material unchanged |
+
+---
+
+## 10. Open Questions
+
+1. **GitHub API for publishing** — Should Phase 7 use the GitHub Contents API as a cloud alternative to git push? This would make publishing fully portable but adds complexity and a new dependency.
+
+2. **Cowork file access** — Can Cowork sessions access uploaded images for Phase 0? Need to verify the `mcp__cowork__request_cowork_directory` capability and its limitations.
+
+3. **API key management in cloud** — How do Square API tokens get to cloud/Cowork environments? MCP server config? Environment variables? Secret injection?
+
+4. **Deferred action notification** — How does the user know there are deferred actions when they open a new Mac CLI session? Hook? Skill startup check? CLAUDE.md instruction?
+
+5. **Windows support** — Is this a real requirement or theoretical? If real, need PowerShell equivalents for osascript patterns and a Windows-native Photos alternative.
+
+6. **Multi-user** — Should state files support multiple users/machines, or is this strictly single-user (scottybe's workflow)?
+
+---
+
+## 11. Success Criteria
+
+| Criteria | Measurement |
+|----------|-------------|
+| All existing tests pass | `pytest testing/` green |
+| New unit tests for state machine + queue | 15+ test cases passing |
+| Env detection works in Mac CLI | `detect_env.py` returns correct capabilities |
+| Portable phases run in Cowork | Phases 1-5 complete without osascript |
+| Deferred actions round-trip | Phase deferred in Cowork, executed on Mac |
+| Photos polling discovers clusters | New clusters detected, presented to user |
+| Batch isolation maintained | 1 item failure doesn't stop batch of 5 |
+| Cowork communication is conversational | Natural language progress, not structured logs |
+| Architecture audit score >= 9.0 | Updated ARCHITECTURE_AUDIT.md |
+
+---
+
+## Appendix A: Current v4.0 Test Failures
+
+```python
+# test_rg_full_auto_catalog_fallback.py line 38:
+processor = RGItemProcessor(interactive=False)
+# FAILS: __init__() got unexpected keyword argument 'interactive'
+# v4.0 removed interactive param (everything is autonomous now)
+
+# test_rg_full_auto_catalog_fallback.py line 64:
+result = processor.phase3_catalog(_item_data())
+# FAILS: 'RGItemProcessor' has no attribute 'phase3_catalog'
+# v4.0 renamed to _phase_2() with different signature (takes ItemState, not dict)
+```
+
+## Appendix B: Environment Detection Pseudocode
+
+```python
+def detect_environment() -> dict:
+    caps = {}
+
+    # osascript check
+    caps["has_osascript"] = shutil.which("osascript") is not None
+
+    # Filesystem check
+    caps["has_filesystem"] = os.path.isdir(os.path.expanduser("~/workspace"))
+
+    # Square token
+    caps["has_square_token"] = bool(os.environ.get("SQUARE_ACCESS_TOKEN"))
+
+    # Photos.app database
+    photos_db = os.path.expanduser(
+        "~/Pictures/Photos Library.photoslibrary/database/Photos.sqlite"
+    )
+    caps["has_photos_db"] = os.path.isfile(photos_db)
+
+    # Git
+    caps["has_git"] = shutil.which("git") is not None
+
+    # Image processing APIs
+    caps["has_removebg"] = bool(os.environ.get("REMOVEBG_API_KEY"))
+    caps["has_image_api"] = caps["has_removebg"] or bool(
+        os.environ.get("GEMINI_API_KEY") or os.environ.get("NANO_BANANA_API_KEY")
+    )
+
+    # Determine environment
+    if caps["has_osascript"] and caps["has_photos_db"]:
+        caps["environment"] = "mac_cli"
+    elif caps["has_filesystem"] and caps["has_git"]:
+        caps["environment"] = "linux_cli"
+    elif os.environ.get("CLAUDE_COWORK"):
+        caps["environment"] = "cowork"
+    else:
+        caps["environment"] = "cloud"
+
+    # Interaction mode
+    caps["interaction_mode"] = "chat" if caps["environment"] == "cowork" else "cli"
+
+    return caps
+```

--- a/rg-full-auto/docs/plans/2026-05-13-v6-pr1-infrastructure.md
+++ b/rg-full-auto/docs/plans/2026-05-13-v6-pr1-infrastructure.md
@@ -1,0 +1,1042 @@
+# rg-full-auto v6.0 — PR #1 (Infrastructure) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Land the v6.0 infrastructure (per-item state machine, centralized queue, audit-log writer) on `main` with **zero behavior change**. After this PR, v3.7's interactive flow still runs verbatim; the new infrastructure exists but is dormant. PRs #2 and #3 activate it.
+
+**Architecture:** Three new Python modules (`item_state.py`, `onboarding_queue.py`, `audit_log.py`) under `rg-full-auto/scripts/`, plus optional hooks in the existing `process_new_item.py` that are no-ops unless an explicit `--use-state` flag is set. JSONL audit-log file initialization at known paths. Tests-first throughout.
+
+**Tech Stack:** Python 3.12, stdlib only (`json`, `pathlib`, `dataclasses`, `datetime`, `enum`, `argparse`, `uuid`). Tests: `pytest` (already configured at `skills/pyproject.toml`).
+
+---
+
+## Pre-flight checks
+
+Run these before starting Task 1. If any fail, stop and surface to the user.
+
+```bash
+cd ~/workspace/richmondgeneral/skills
+git status -sb                            # Expected: clean, on docs/v6-super-full-auto-design
+ls rg-full-auto/docs/plans/               # Expected: design doc + this plan
+python3 -m pytest testing/unit/ -q 2>&1 | tail -5
+                                          # Expected: existing 125 tests pass
+                                          # (or whatever baseline count is current)
+```
+
+Confirm the existing rg-full-auto tests are broken per design doc §test:
+
+```bash
+ls testing/integration/test_rg_full_auto* 2>&1
+python3 -m pytest testing/integration/test_rg_full_auto_catalog_fallback.py -q 2>&1 | tail -10
+```
+Expected: collection errors or test failures referencing the v3.x API. **Do not fix these — they get replaced by the v6.0 test layer.** Note count of failing tests so we can confirm we didn't regress anything else.
+
+---
+
+## Task 1: Branch off from PR #14's branch
+
+**Files:** none (git only)
+
+**Step 1: Confirm PR #14 has been merged to main**
+
+```bash
+gh pr view 14 --json state,baseRefName 2>&1 | head -3
+```
+Expected: `"state":"MERGED"`. If still `"OPEN"`, surface to user — this plan depends on the design doc being on main so the state.json schema reference resolves.
+
+**Step 2: Sync main and branch off**
+
+```bash
+git checkout main && git pull
+git checkout -b feat/v6-pr1-infra-statemachine
+```
+
+**Step 3: Commit a marker file so subsequent commits have a clean ancestor**
+
+(skip — start commits with real work)
+
+---
+
+## Task 2: Create `item_state.py` with TDD
+
+**Files:**
+- Create: `rg-full-auto/scripts/item_state.py`
+- Test: `testing/unit/test_item_state.py`
+
+The branch's version exists at `claude/refactor-auto-onboarding-TyZdT:rg-full-auto/scripts/item_state.py` — we use it as a reference but write tests-first against the **design doc's spec** (`docs/plans/2026-05-13-v6-super-full-auto-design.md` §2.1), not against the branch code directly.
+
+### Step 1: Write the failing test for PhaseStatus + ItemStatus enums
+
+Create `testing/unit/test_item_state.py` with:
+
+```python
+"""Tests for rg-full-auto v6.0 per-item state machine."""
+import pytest
+from item_state import PhaseStatus, ItemStatus
+
+
+def test_phase_status_values():
+    """PhaseStatus enum values match design doc spec."""
+    assert PhaseStatus.PENDING.value == "pending"
+    assert PhaseStatus.IN_PROGRESS.value == "in_progress"
+    assert PhaseStatus.COMPLETED.value == "completed"
+    assert PhaseStatus.FAILED.value == "failed"
+    assert PhaseStatus.BLOCKED.value == "blocked"
+    assert PhaseStatus.SKIPPED.value == "skipped"
+
+
+def test_item_status_values():
+    """ItemStatus enum values match design doc spec."""
+    assert ItemStatus.QUEUED.value == "queued"
+    assert ItemStatus.PROCESSING.value == "processing"
+    assert ItemStatus.BLOCKED.value == "blocked"
+    assert ItemStatus.COMPLETED.value == "completed"
+    assert ItemStatus.FAILED.value == "failed"
+```
+
+### Step 2: Run test — confirm failure
+
+```bash
+python3 -m pytest testing/unit/test_item_state.py -v 2>&1 | tail -10
+```
+Expected: ImportError / ModuleNotFoundError on `item_state` import.
+
+### Step 3: Lift `item_state.py` enum block from the branch
+
+```bash
+git show claude/refactor-auto-onboarding-TyZdT:rg-full-auto/scripts/item_state.py \
+  > /tmp/branch-item-state.py
+head -50 /tmp/branch-item-state.py
+```
+
+Create `rg-full-auto/scripts/item_state.py` with the enums (only the enum portion for this step):
+
+```python
+#!/usr/bin/env python3
+"""
+Per-item state machine for rg-full-auto batch onboarding.
+
+Tracks each item through the 10-phase pipeline independently.
+State persists as .state.json inside each item's folder, enabling:
+- Resume after failures
+- Async user clarification (park → continue)
+- Cross-session persistence
+
+State file: <items_dir>/RG-XXXX/.state.json
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+class PhaseStatus(str, Enum):
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    BLOCKED = "blocked"       # Waiting on user input or external dependency
+    SKIPPED = "skipped"       # Intentionally skipped (e.g., no Whatnot listing)
+
+
+class ItemStatus(str, Enum):
+    QUEUED = "queued"
+    PROCESSING = "processing"
+    BLOCKED = "blocked"       # At least one phase needs user input
+    COMPLETED = "completed"
+    FAILED = "failed"         # Unrecoverable failure
+```
+
+### Step 4: Run test — confirm pass
+
+```bash
+python3 -m pytest testing/unit/test_item_state.py -v 2>&1 | tail -10
+```
+Expected: 2 passed.
+
+### Step 5: Commit
+
+```bash
+git add rg-full-auto/scripts/item_state.py testing/unit/test_item_state.py
+git commit -m "feat: item_state — phase/item status enums (v6.0 infra)"
+```
+
+---
+
+## Task 3: `item_state.py` — phase data + state dataclass
+
+**Files:**
+- Modify: `rg-full-auto/scripts/item_state.py` (append)
+- Modify: `testing/unit/test_item_state.py` (append)
+
+### Step 1: Write failing test for `PhaseData` dataclass
+
+Append to `testing/unit/test_item_state.py`:
+
+```python
+from item_state import PhaseData
+
+
+def test_phase_data_default():
+    """PhaseData starts in PENDING with empty outputs."""
+    p = PhaseData()
+    assert p.status == PhaseStatus.PENDING
+    assert p.started_at is None
+    assert p.completed_at is None
+    assert p.outputs == {}
+    assert p.error is None
+
+
+def test_phase_data_to_dict():
+    """PhaseData serializes to JSON-safe dict."""
+    p = PhaseData(status=PhaseStatus.COMPLETED, outputs={"k": "v"})
+    d = p.to_dict()
+    assert d["status"] == "completed"
+    assert d["outputs"] == {"k": "v"}
+```
+
+### Step 2: Run test — confirm failure
+
+```bash
+python3 -m pytest testing/unit/test_item_state.py::test_phase_data_default -v 2>&1 | tail -5
+```
+Expected: ImportError on `PhaseData`.
+
+### Step 3: Add `PhaseData` to `item_state.py`
+
+Append after the enums:
+
+```python
+@dataclass
+class PhaseData:
+    """One phase's status + outputs for a single item."""
+    status: PhaseStatus = PhaseStatus.PENDING
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    duration_s: Optional[float] = None
+    outputs: Dict[str, Any] = field(default_factory=dict)
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = asdict(self)
+        d["status"] = self.status.value
+        return d
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "PhaseData":
+        d = dict(d)
+        d["status"] = PhaseStatus(d.get("status", "pending"))
+        return cls(**d)
+```
+
+### Step 4: Run tests — confirm pass
+
+```bash
+python3 -m pytest testing/unit/test_item_state.py -v 2>&1 | tail -10
+```
+Expected: 4 passed.
+
+### Step 5: Commit
+
+```bash
+git add -A
+git commit -m "feat: item_state — PhaseData dataclass with to_dict/from_dict"
+```
+
+---
+
+## Task 4: `ItemState` — load/save/transition
+
+**Files:**
+- Modify: `rg-full-auto/scripts/item_state.py`
+- Modify: `testing/unit/test_item_state.py`
+
+### Step 1: Write failing tests for ItemState lifecycle
+
+Append to test file:
+
+```python
+from item_state import ItemState
+from pathlib import Path
+import json
+
+
+def test_item_state_new(tmp_path):
+    """A new ItemState initializes empty phases + QUEUED status."""
+    state = ItemState(sku="RG-0099", items_dir=str(tmp_path))
+    assert state.sku == "RG-0099"
+    assert state.status == ItemStatus.QUEUED
+    assert state.decisions == []
+    assert state.questions == []
+    # Phases initialize as PENDING for the canonical 10 phases.
+    assert "phase_0" in state.phases
+    assert "phase_9" in state.phases
+    assert state.phases["phase_0"].status == PhaseStatus.PENDING
+
+
+def test_item_state_save_and_load(tmp_path):
+    """ItemState round-trips through .state.json on disk."""
+    state = ItemState(sku="RG-0099", items_dir=str(tmp_path))
+    state.status = ItemStatus.PROCESSING
+    state.phases["phase_0"].status = PhaseStatus.COMPLETED
+    (tmp_path / "RG-0099").mkdir()
+    state.save()
+    state_file = tmp_path / "RG-0099" / ".state.json"
+    assert state_file.exists()
+    loaded = ItemState.load("RG-0099", items_dir=str(tmp_path))
+    assert loaded.status == ItemStatus.PROCESSING
+    assert loaded.phases["phase_0"].status == PhaseStatus.COMPLETED
+
+
+def test_item_state_load_legacy_item_no_state(tmp_path):
+    """Loading an item without .state.json returns None (legacy mode)."""
+    (tmp_path / "RG-0001").mkdir()
+    loaded = ItemState.load("RG-0001", items_dir=str(tmp_path))
+    assert loaded is None
+```
+
+### Step 2: Run tests — confirm failure
+
+```bash
+python3 -m pytest testing/unit/test_item_state.py::test_item_state_new -v 2>&1 | tail -10
+```
+Expected: ImportError on `ItemState`.
+
+### Step 3: Implement `ItemState` class
+
+Append to `item_state.py`:
+
+```python
+# Canonical 10-phase sequence. Phase numbers align with SKILL.md §Phase 0..9.
+PHASES = [f"phase_{i}" for i in range(10)]
+
+
+@dataclass
+class ItemState:
+    """Per-item state container; persists to <items_dir>/<sku>/.state.json."""
+    sku: str
+    items_dir: str = "/Users/scottybe/workspace/square/items"
+    status: ItemStatus = ItemStatus.QUEUED
+    source_image: Optional[str] = None
+    created_at: str = ""
+    updated_at: str = ""
+    created_in: str = "mac_cli"   # mac_cli | linux_cli | cowork | cloud
+    phases: Dict[str, PhaseData] = field(default_factory=dict)
+    decisions: List[Dict[str, Any]] = field(default_factory=list)
+    questions: List[Dict[str, Any]] = field(default_factory=list)
+    review: Dict[str, Any] = field(default_factory=lambda: {
+        "agent_finished_at": None,
+        "human_reviewed_at": None,
+        "elapsed_review_s": None,
+        "outcome": None,
+    })
+
+    def __post_init__(self):
+        if not self.phases:
+            self.phases = {p: PhaseData() for p in PHASES}
+        now = datetime.now(timezone.utc).isoformat()
+        if not self.created_at:
+            self.created_at = now
+        self.updated_at = now
+
+    @property
+    def state_file(self) -> Path:
+        return Path(self.items_dir) / self.sku / ".state.json"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "sku": self.sku,
+            "status": self.status.value,
+            "source_image": self.source_image,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "created_in": self.created_in,
+            "phases": {k: v.to_dict() for k, v in self.phases.items()},
+            "decisions": self.decisions,
+            "questions": self.questions,
+            "review": self.review,
+        }
+
+    def save(self) -> None:
+        """Write .state.json. Parent dir must exist."""
+        self.updated_at = datetime.now(timezone.utc).isoformat()
+        self.state_file.write_text(
+            json.dumps(self.to_dict(), indent=2),
+            encoding="utf-8",
+        )
+
+    @classmethod
+    def load(cls, sku: str, items_dir: str = "/Users/scottybe/workspace/square/items") -> Optional["ItemState"]:
+        """Load .state.json from disk. Returns None if no state file
+        (legacy item that predates v6.0)."""
+        path = Path(items_dir) / sku / ".state.json"
+        if not path.exists():
+            return None
+        d = json.loads(path.read_text(encoding="utf-8"))
+        phases = {k: PhaseData.from_dict(v) for k, v in d.get("phases", {}).items()}
+        return cls(
+            sku=d["sku"],
+            items_dir=items_dir,
+            status=ItemStatus(d.get("status", "queued")),
+            source_image=d.get("source_image"),
+            created_at=d.get("created_at", ""),
+            updated_at=d.get("updated_at", ""),
+            created_in=d.get("created_in", "mac_cli"),
+            phases=phases,
+            decisions=d.get("decisions", []),
+            questions=d.get("questions", []),
+            review=d.get("review", {}),
+        )
+```
+
+### Step 4: Run tests — confirm pass
+
+```bash
+python3 -m pytest testing/unit/test_item_state.py -v 2>&1 | tail -15
+```
+Expected: 7 passed.
+
+### Step 5: Commit
+
+```bash
+git add -A
+git commit -m "feat: item_state — ItemState class with save/load and legacy detection"
+```
+
+---
+
+## Task 5: `onboarding_queue.py` — port from branch with TDD
+
+**Files:**
+- Create: `rg-full-auto/scripts/onboarding_queue.py`
+- Create: `testing/unit/test_onboarding_queue.py`
+
+The branch's version at `claude/refactor-auto-onboarding-TyZdT:rg-full-auto/scripts/onboarding_queue.py` is the reference. Same pattern as Task 2/3/4: tests-first, port code, validate.
+
+### Step 1: Write failing tests
+
+Create `testing/unit/test_onboarding_queue.py`:
+
+```python
+"""Tests for the centralized onboarding queue."""
+import pytest
+from onboarding_queue import OnboardingQueue, QueueEntry
+from item_state import ItemStatus
+from pathlib import Path
+import json
+
+
+def test_queue_add_entry(tmp_path):
+    """Adding an entry shows up in the queue file."""
+    queue_file = tmp_path / "queue.json"
+    q = OnboardingQueue(queue_path=str(queue_file))
+    q.upsert(QueueEntry(sku="RG-0099", status=ItemStatus.QUEUED.value))
+    q.save()
+    data = json.loads(queue_file.read_text())
+    assert any(e["sku"] == "RG-0099" for e in data["entries"])
+
+
+def test_queue_upsert_updates_existing(tmp_path):
+    """Upserting same SKU twice updates rather than duplicates."""
+    queue_file = tmp_path / "queue.json"
+    q = OnboardingQueue(queue_path=str(queue_file))
+    q.upsert(QueueEntry(sku="RG-0099", status="queued"))
+    q.upsert(QueueEntry(sku="RG-0099", status="processing"))
+    q.save()
+    data = json.loads(queue_file.read_text())
+    matching = [e for e in data["entries"] if e["sku"] == "RG-0099"]
+    assert len(matching) == 1
+    assert matching[0]["status"] == "processing"
+
+
+def test_queue_remove(tmp_path):
+    """Removing by SKU drops the entry."""
+    queue_file = tmp_path / "queue.json"
+    q = OnboardingQueue(queue_path=str(queue_file))
+    q.upsert(QueueEntry(sku="RG-0099", status="queued"))
+    q.upsert(QueueEntry(sku="RG-0100", status="queued"))
+    q.remove("RG-0099")
+    q.save()
+    data = json.loads(queue_file.read_text())
+    assert not any(e["sku"] == "RG-0099" for e in data["entries"])
+    assert any(e["sku"] == "RG-0100" for e in data["entries"])
+
+
+def test_queue_load_missing_file(tmp_path):
+    """Loading a non-existent queue file yields an empty queue."""
+    queue_file = tmp_path / "does-not-exist.json"
+    q = OnboardingQueue(queue_path=str(queue_file))
+    assert q.entries == []
+```
+
+### Step 2: Run tests — confirm failure
+
+```bash
+python3 -m pytest testing/unit/test_onboarding_queue.py -v 2>&1 | tail -10
+```
+Expected: ImportError on `onboarding_queue`.
+
+### Step 3: Port the branch's `onboarding_queue.py` selectively
+
+Don't blindly copy — the branch may have idioms we'd rather replace. Open `/tmp/branch-onboarding-queue.py` first to read:
+
+```bash
+git show claude/refactor-auto-onboarding-TyZdT:rg-full-auto/scripts/onboarding_queue.py > /tmp/branch-onboarding-queue.py
+wc -l /tmp/branch-onboarding-queue.py
+```
+
+Create `rg-full-auto/scripts/onboarding_queue.py` with the minimum surface to make the tests pass:
+
+```python
+#!/usr/bin/env python3
+"""
+Centralized onboarding queue for rg-full-auto batch processing.
+
+Maintains a single queue file in the ops repo that tracks all items
+currently being onboarded, their statuses, and pending questions.
+
+Queue file: <queue_path> (default: ops/inventory/onboarding-queue.json)
+This provides a dashboard view across all in-flight items while
+per-item .state.json files hold the detailed phase-level state.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+DEFAULT_QUEUE_PATH = "/Users/scottybe/workspace/square/ops/inventory/onboarding-queue.json"
+
+
+@dataclass
+class QueueEntry:
+    """Summary record for one item in the centralized queue."""
+    sku: str
+    status: str                          # mirrors ItemStatus.value
+    source_image: Optional[str] = None
+    created_at: str = ""
+    updated_at: str = ""
+    phases_completed: int = 0
+    phases_total: int = 10
+    pending_questions: int = 0
+
+    def __post_init__(self):
+        now = datetime.now(timezone.utc).isoformat()
+        if not self.created_at:
+            self.created_at = now
+        self.updated_at = now
+
+
+@dataclass
+class OnboardingQueue:
+    """Mutable queue object. `load_from_disk` is automatic on construction
+    if the queue file exists; `save()` writes back."""
+    queue_path: str = DEFAULT_QUEUE_PATH
+    entries: List[QueueEntry] = field(default_factory=list)
+
+    def __post_init__(self):
+        path = Path(self.queue_path)
+        if path.exists():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            self.entries = [QueueEntry(**e) for e in data.get("entries", [])]
+
+    def upsert(self, entry: QueueEntry) -> None:
+        """Insert new, or update existing entry with the same SKU."""
+        for i, e in enumerate(self.entries):
+            if e.sku == entry.sku:
+                self.entries[i] = entry
+                return
+        self.entries.append(entry)
+
+    def remove(self, sku: str) -> None:
+        self.entries = [e for e in self.entries if e.sku != sku]
+
+    def find(self, sku: str) -> Optional[QueueEntry]:
+        return next((e for e in self.entries if e.sku == sku), None)
+
+    def save(self) -> None:
+        """Atomic write — create parent dir, write to temp, rename."""
+        path = Path(self.queue_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        payload = {
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            "entries": [asdict(e) for e in self.entries],
+        }
+        tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        tmp.replace(path)
+```
+
+### Step 4: Run tests — confirm pass
+
+```bash
+python3 -m pytest testing/unit/test_onboarding_queue.py -v 2>&1 | tail -10
+```
+Expected: 4 passed.
+
+### Step 5: Commit
+
+```bash
+git add -A
+git commit -m "feat: onboarding_queue — upsert/remove/atomic-save with TDD"
+```
+
+---
+
+## Task 6: `audit_log.py` — NEW writer for the three JSONL streams
+
+**Files:**
+- Create: `rg-full-auto/scripts/audit_log.py`
+- Create: `testing/unit/test_audit_log.py`
+
+This is the NEW file (per design §3.2). The three streams are `decisions.jsonl`, `corrections.jsonl`, `review_log.jsonl`. JSONL append-only.
+
+### Step 1: Write failing tests
+
+Create `testing/unit/test_audit_log.py`:
+
+```python
+"""Tests for v6.0 audit-log writer."""
+import pytest
+import json
+from pathlib import Path
+from audit_log import AuditLog
+
+
+def test_log_decision_appends_jsonl(tmp_path):
+    """Logging a decision appends one JSONL line."""
+    log_dir = tmp_path
+    al = AuditLog(log_dir=str(log_dir))
+    al.log_decision(
+        sku="RG-0099",
+        phase="phase_1",
+        decision_type="price",
+        choice=18.50,
+        confidence=0.78,
+        inputs_considered={"era": "1979"},
+        alternatives_seen=[],
+        rationale="midpoint of comps",
+    )
+    decisions_file = log_dir / "decisions.jsonl"
+    assert decisions_file.exists()
+    lines = decisions_file.read_text().strip().split("\n")
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["sku"] == "RG-0099"
+    assert record["choice"] == 18.50
+    assert record["confidence"] == 0.78
+
+
+def test_log_correction_includes_diff(tmp_path):
+    """Logging a correction captures agent_choice vs corrected_to."""
+    al = AuditLog(log_dir=str(tmp_path))
+    al.log_correction(
+        sku="RG-0099",
+        decision_id="dec-001",
+        decision_type="price",
+        agent_choice=18.50,
+        corrected_to=22.00,
+        correction_source="manual",
+        reason="underpriced for the condition",
+        reviewer="scottybe",
+    )
+    record = json.loads((tmp_path / "corrections.jsonl").read_text().strip())
+    assert record["agent_choice"] == 18.50
+    assert record["corrected_to"] == 22.00
+    assert record["correction_source"] == "manual"
+
+
+def test_log_review_event(tmp_path):
+    """review_log captures start + end events with duration."""
+    al = AuditLog(log_dir=str(tmp_path))
+    al.log_review_event(sku="RG-0099", event="review_started")
+    al.log_review_event(
+        sku="RG-0099",
+        event="review_completed",
+        duration_s=324,
+        corrections_applied=2,
+        outcome="accepted_with_corrections",
+    )
+    lines = (tmp_path / "review_log.jsonl").read_text().strip().split("\n")
+    assert len(lines) == 2
+    end = json.loads(lines[1])
+    assert end["duration_s"] == 324
+    assert end["outcome"] == "accepted_with_corrections"
+
+
+def test_concurrent_appends_dont_corrupt(tmp_path):
+    """Multiple appends in quick succession produce valid JSONL."""
+    al = AuditLog(log_dir=str(tmp_path))
+    for i in range(20):
+        al.log_decision(
+            sku=f"RG-{i:04d}",
+            phase="phase_1",
+            decision_type="price",
+            choice=10.0 + i,
+            confidence=0.5,
+            inputs_considered={},
+            alternatives_seen=[],
+            rationale="test",
+        )
+    lines = (tmp_path / "decisions.jsonl").read_text().strip().split("\n")
+    assert len(lines) == 20
+    # Every line must parse as valid JSON.
+    for line in lines:
+        json.loads(line)
+```
+
+### Step 2: Run tests — confirm failure
+
+```bash
+python3 -m pytest testing/unit/test_audit_log.py -v 2>&1 | tail -10
+```
+Expected: ImportError on `audit_log`.
+
+### Step 3: Implement `AuditLog`
+
+Create `rg-full-auto/scripts/audit_log.py`:
+
+```python
+#!/usr/bin/env python3
+"""
+Audit-log writer for rg-full-auto v6.0.
+
+Three append-only JSONL streams under <log_dir>:
+  decisions.jsonl    — every autonomous decision the agent made
+  corrections.jsonl  — human corrections to those decisions, plus
+                       auto-detected drift between agent's choice
+                       and current Square/state-on-disk
+  review_log.jsonl   — review-timing events (started, completed)
+                       + outcomes, for L2 time tracking
+
+Default log_dir: /Users/scottybe/workspace/square/ops/inventory/
+
+JSONL = one JSON object per line, append-only. Lets us grep/jq with
+zero parse overhead and never rewrite the whole file.
+
+CLI subcommands (planned but not all built in PR #1):
+  audit_log.py report --sku <SKU>
+  audit_log.py report --since <DATE>
+  audit_log.py review-stats
+  audit_log.py drift
+  audit_log.py correct --sku ... --decision ... --new ... --reason ...
+"""
+from __future__ import annotations
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+DEFAULT_LOG_DIR = "/Users/scottybe/workspace/square/ops/inventory"
+
+
+class AuditLog:
+    """Append-only JSONL writer for the three audit streams."""
+
+    def __init__(self, log_dir: str = DEFAULT_LOG_DIR):
+        self.log_dir = Path(log_dir)
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+        self.decisions_path = self.log_dir / "decisions.jsonl"
+        self.corrections_path = self.log_dir / "corrections.jsonl"
+        self.review_log_path = self.log_dir / "review_log.jsonl"
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    def _append(self, path: Path, record: Dict[str, Any]) -> None:
+        """Append one JSON object as a single line. Atomic at the OS
+        level for line-sized writes on a single host (POSIX append)."""
+        line = json.dumps(record, ensure_ascii=False) + "\n"
+        with path.open("a", encoding="utf-8") as f:
+            f.write(line)
+
+    def log_decision(
+        self,
+        sku: str,
+        phase: str,
+        decision_type: str,
+        choice: Any,
+        confidence: float,
+        inputs_considered: Dict[str, Any],
+        alternatives_seen: List[Dict[str, Any]],
+        rationale: str,
+        decision_id: Optional[str] = None,
+    ) -> str:
+        """Append one decision; returns the decision_id."""
+        decision_id = decision_id or f"dec-{uuid.uuid4().hex[:8]}"
+        record = {
+            "ts": self._now(),
+            "decision_id": decision_id,
+            "sku": sku,
+            "phase": phase,
+            "type": decision_type,
+            "choice": choice,
+            "confidence": confidence,
+            "inputs_considered": inputs_considered,
+            "alternatives_seen": alternatives_seen,
+            "rationale": rationale,
+        }
+        self._append(self.decisions_path, record)
+        return decision_id
+
+    def log_correction(
+        self,
+        sku: str,
+        decision_id: str,
+        decision_type: str,
+        agent_choice: Any,
+        corrected_to: Any,
+        correction_source: str,        # "manual" | "auto-diff"
+        reason: str,
+        reviewer: str,
+    ) -> None:
+        record = {
+            "ts": self._now(),
+            "sku": sku,
+            "decision_id": decision_id,
+            "decision_type": decision_type,
+            "agent_choice": agent_choice,
+            "corrected_to": corrected_to,
+            "correction_source": correction_source,
+            "reason": reason,
+            "reviewer": reviewer,
+        }
+        self._append(self.corrections_path, record)
+
+    def log_review_event(
+        self,
+        sku: str,
+        event: str,                    # "review_started" | "review_completed"
+        duration_s: Optional[int] = None,
+        corrections_applied: Optional[int] = None,
+        outcome: Optional[str] = None, # accepted_as_is | accepted_with_corrections | rejected_redo
+    ) -> None:
+        record: Dict[str, Any] = {
+            "ts": self._now(),
+            "sku": sku,
+            "event": event,
+        }
+        if duration_s is not None:
+            record["duration_s"] = duration_s
+        if corrections_applied is not None:
+            record["corrections_applied"] = corrections_applied
+        if outcome is not None:
+            record["outcome"] = outcome
+        self._append(self.review_log_path, record)
+```
+
+### Step 4: Run tests — confirm pass
+
+```bash
+python3 -m pytest testing/unit/test_audit_log.py -v 2>&1 | tail -10
+```
+Expected: 4 passed.
+
+### Step 5: Commit
+
+```bash
+git add -A
+git commit -m "feat: audit_log — append-only JSONL writer for decisions/corrections/review_log"
+```
+
+---
+
+## Task 7: Sanity-check the conftest path setup
+
+The skills repo's `testing/conftest.py` already injects each skill's `scripts/` dir into `sys.path` so tests can `from item_state import ...`. Verify the rg-full-auto path is there.
+
+**Step 1: Read conftest**
+
+```bash
+grep "rg-full-auto" testing/conftest.py
+```
+Expected: a line like `"rg-full-auto/scripts",` in the SKILL_DIRS list.
+
+**Step 2: If missing, add it**
+
+If grep returns nothing:
+
+```python
+# Add to testing/conftest.py SKILL_DIRS list:
+"rg-full-auto/scripts",
+```
+
+And commit:
+
+```bash
+git add testing/conftest.py
+git commit -m "test: add rg-full-auto/scripts to conftest sys.path"
+```
+
+If already there: skip.
+
+---
+
+## Task 8: Run the full unit suite — no regressions
+
+**Step 1: Run all unit tests**
+
+```bash
+python3 -m pytest testing/unit/ -q 2>&1 | tail -10
+```
+Expected: all pre-existing tests still pass + the new tests pass. Compare count to the pre-flight baseline. New tests added: 11 (`test_item_state.py` 7, `test_onboarding_queue.py` 4, `test_audit_log.py` 4 — wait, also re-count). Adjust expected count up by exactly that many.
+
+**Step 2: If anything regressed**
+
+Surface to user; do NOT mask or work around. The infra is supposed to be additive.
+
+---
+
+## Task 9: SKILL.md — minimal addition noting the new infra (no behavior change)
+
+**Files:**
+- Modify: `rg-full-auto/SKILL.md`
+
+The bigger SKILL.md rewrite happens in PR #2/#3. For PR #1, just add a section under "Architecture" mentioning the new files so anyone reading the skill knows they exist.
+
+**Step 1: Read current SKILL.md architecture section**
+
+```bash
+grep -n "^## \|^### " rg-full-auto/SKILL.md | head -20
+```
+
+**Step 2: Insert a "## v6.0 Infrastructure (dormant)" section**
+
+Add after the current Architecture section:
+
+```markdown
+## v6.0 Infrastructure (dormant in v3.7 behavior)
+
+PR #1 of the v6.0 ship landed three new modules. **None are active in the default flow** — v3.7 interactive behavior is unchanged. They exist so PR #2 can wire them up:
+
+| Module | Purpose |
+|---|---|
+| `scripts/item_state.py` | Per-item state machine. Will persist `.state.json` in each item folder once Phase #2 activates it. |
+| `scripts/onboarding_queue.py` | Centralized queue dashboard. Will write `ops/inventory/onboarding-queue.json` once activated. |
+| `scripts/audit_log.py` | Append-only JSONL writer for `decisions.jsonl`, `corrections.jsonl`, `review_log.jsonl`. Used by v6.0's "agent decides, user reviews" autonomy flow. |
+
+Design: `docs/plans/2026-05-13-v6-super-full-auto-design.md`
+v5.0 portability (deferred): `docs/plans/2026-05-13-v5-portability-deferred.md`
+```
+
+**Step 3: Commit**
+
+```bash
+git add rg-full-auto/SKILL.md
+git commit -m "docs: SKILL.md note v6.0 infra modules (dormant in v3.7 flow)"
+```
+
+---
+
+## Task 10: Open the PR
+
+**Step 1: Push the branch**
+
+```bash
+git push -u origin feat/v6-pr1-infra-statemachine 2>&1 | tail -3
+```
+
+**Step 2: Open the PR**
+
+```bash
+gh pr create --base main --head feat/v6-pr1-infra-statemachine \
+  --title "feat: rg-full-auto v6.0 PR #1 — infrastructure (state machine + queue + audit log)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+First of three staged PRs to land rg-full-auto v6.0 per the design at `rg-full-auto/docs/plans/2026-05-13-v6-super-full-auto-design.md`.
+
+**Behavior change: ZERO.** Three new modules added to `rg-full-auto/scripts/`. v3.7 interactive flow runs unchanged. PR #2 wires them up.
+
+## What's in this PR
+
+| File | Lines | Purpose |
+|---|---|---|
+| `rg-full-auto/scripts/item_state.py` | ~150 | Per-item state machine; `.state.json` writer |
+| `rg-full-auto/scripts/onboarding_queue.py` | ~80 | Centralized queue dashboard |
+| `rg-full-auto/scripts/audit_log.py` | ~130 | Append-only JSONL writer for the three audit streams |
+| `testing/unit/test_item_state.py` | ~80 | Lifecycle tests for state machine |
+| `testing/unit/test_onboarding_queue.py` | ~60 | Upsert/remove/atomic-save tests |
+| `testing/unit/test_audit_log.py` | ~80 | JSONL append + concurrent-write tests |
+| `rg-full-auto/SKILL.md` | +20 | Note the dormant infrastructure |
+
+## Test plan
+- [x] All pre-existing unit tests still pass (no regressions)
+- [x] 15+ new tests added covering state machine + queue + audit log
+- [x] No live API calls; everything mocked or filesystem
+- [x] v3.7 interactive flow unchanged (verified by running existing integration tests)
+
+## Next
+PR #2: process_batch.py + `--autonomous` flag (opt-in)
+PR #3: flip default to autonomous; v6.0 becomes the documented norm
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)" 2>&1 | tail -2
+```
+
+---
+
+## Task 11: Verification before claiming done
+
+Use the `superpowers:verification-before-completion` skill discipline:
+
+**Step 1: Confirm all tests pass on the new branch**
+
+```bash
+python3 -m pytest testing/unit/ -q 2>&1 | tail -5
+```
+Expected: all green.
+
+**Step 2: Confirm no behavioral changes to v3.7 flow**
+
+```bash
+python3 -m pytest testing/integration/ -q 2>&1 | tail -10
+```
+Expected: same count of passes/failures as before PR (the pre-existing broken integration tests stay broken — they get replaced in PR #3, not this one).
+
+**Step 3: Confirm git state is clean**
+
+```bash
+git status -sb
+```
+Expected: nothing uncommitted; branch synced to origin.
+
+**Step 4: Confirm the PR is open and links the design**
+
+```bash
+gh pr view --json url,state | head
+```
+
+**Step 5: Report**
+
+Surface to user: PR URL, test count diff, anything unexpected.
+
+---
+
+## Open questions / known limitations
+
+- `audit_log.py` CLI subcommands (`report`, `review-stats`, `drift`, `correct`) are NOT built in PR #1. The library functions exist; the argparse layer comes in PR #2 alongside the autonomous flag (because that's when the data starts accumulating and the CLI starts being useful).
+- The default paths in each module (`/Users/scottybe/workspace/square/items` and `/Users/scottybe/workspace/square/ops/inventory`) are hardcoded — same as v3.7. Multi-environment support (cowork, cloud) is v5.0's epic, NOT this PR.
+- No JSON schema validation on `.state.json` or queue file. Pydantic was considered and rejected — stdlib `dataclasses.asdict` is enough for v6.0; can introduce schemas later if drift becomes a problem.
+- Concurrent batch processing safety: `audit_log._append` uses POSIX append-on-write atomicity which is reliable for line-sized writes on a single host. Multi-host concurrency is out of scope.
+
+## References
+
+- Design doc: `rg-full-auto/docs/plans/2026-05-13-v6-super-full-auto-design.md` (§2 architecture, §3.2 audit schemas)
+- Source branch (read-only reference): `claude/refactor-auto-onboarding-TyZdT`
+- Tests pattern reference: existing `testing/unit/test_rotate_item_images.py` for skill-script test style
+- Skills repo testing config: `testing/conftest.py` + `pyproject.toml`

--- a/rg-full-auto/docs/plans/2026-05-13-v6-super-full-auto-design.md
+++ b/rg-full-auto/docs/plans/2026-05-13-v6-super-full-auto-design.md
@@ -1,0 +1,351 @@
+# rg-full-auto v6.0 — "Super Full Auto" design
+
+**Date:** 2026-05-13
+**Status:** Approved direction, implementation plan pending
+**Owner:** @scottybe
+**Related branch (preserved, NOT being merged as-is):** `claude/refactor-auto-onboarding-TyZdT`
+**Related PRD:** branch's `PRD.md` (560L) — moves into this skill as
+`docs/plans/2026-05-13-v5-portability.md`, deferred future-work, NOT shipping in v6.0
+
+## Context
+
+Three sources are being combined:
+
+1. **Current `main`** — `rg-full-auto` v3.7. Interactive, single-item, supervised.
+   Includes recent fixes (PR sequence ending 2026-05-13): `description_html`
+   field, phase ordering (photography before research), `ROOM_BY_TYPE` map
+   with `TOP_LEVEL_ROOMS` handling, sync_to_whatnot literal-`\n` fix,
+   remove_background response.text leak fix.
+2. **Branch v4.0 (committed Feb 19, 2026)** — batch-first, autonomous,
+   fault-isolated, per-item state machine, centralized queue, async
+   question queue. Working code: `item_state.py` (394L),
+   `onboarding_queue.py` (303L), `process_batch.py` (568L), modified
+   `process_new_item.py` (842L), modified `SKILL.md` (1022L).
+3. **Branch v5.0 PRD (draft, 560L)** — environment-aware capability
+   detection, phase portability classification, deferred-action queue
+   for phases that need a different environment. **Deferred to a future
+   v6.1+ epic; not part of v6.0 scope.**
+
+v6.0 = v3.7's stable + v4.0's autonomy and infrastructure + audit
+trail. v5.0 portability is the next epic after v6.0 stabilizes.
+
+## Decisions taken
+
+| Dimension | Choice | Rejected |
+|---|---|---|
+| Autonomy level | **A: Full v4.0 autonomy.** Agent decides everything (price, condition, shipping, category, draft copy). User reviews post-onboard. | B (milestone checkpoints), C (preserve v3.7 gates with v4.0 engine) |
+| Skill identity | **Major version bump on `rg-full-auto` → v6.0.** "Super" is branding inside the SKILL.md header. Path stays `rg-full-auto/`. | New parallel skill (cross-reference churn), new skill replacing old (same churn) |
+| Audit depth | **L1 (passive structured log) + L2 (time-on-review tracking)** in v6.0. L3 (pattern-detection feedback loop) deferred to v6.1+ when ≥30 items' correction data exists to learn from. | L1 only (no time data), L1+L2+L3 (premature without data) |
+
+## Architecture — three layers
+
+```
+LAYER 1 — SKILL.md
+  Claude's instructions. Phase descriptions, autonomous decision rules,
+  audit-and-review review flow. Bumped from v3.7 to v6.0.
+                            │
+                            ▼
+LAYER 2 — Orchestration (Python, env-agnostic)
+  item_state.py       — per-item FSM, persisted to .state.json
+  onboarding_queue.py — centralized dashboard, ops/inventory/queue.json
+  process_batch.py    — multi-item loop, fault isolation, summary
+  audit_log.py (NEW)  — writes decisions.jsonl, corrections.jsonl,
+                        review_log.jsonl; provides report/review-stats/drift
+                            │
+                            ▼
+LAYER 3 — Phase executors
+  process_new_item.py — single-item phase runner. CURRENT MAIN's version
+                        (with recent fixes intact) is the base. v4.0's
+                        state-machine integration is lifted ONTO it via
+                        thin hooks, NOT vice versa. Branch's rewrite of
+                        this file is discarded.
+  Phase implementations subprocess into sibling skills:
+  square-image-upload, photos-library, rg-lot-tracker, book-appraiser, etc.
+```
+
+**Key choice rationale:** current main's `process_new_item.py` has 3 months
+of bugfixes that the branch's version does not. Re-applying those fixes
+onto the branch's rewrite is more work and more risk than wrapping
+main's version with state-machine hooks.
+
+## Component inventory — what comes from where
+
+| File | Source | Status |
+|---|---|---|
+| `SKILL.md` | Branch v4.0 (25 KB) + main's reference structure | Rewrite — ~600L target, down from branch's 1022L by trimming repetition |
+| `scripts/process_new_item.py` | **Current main** (recent fixes intact) | Wrap with state-machine hooks; logic unchanged |
+| `scripts/process_batch.py` | Branch v4.0 verbatim | Drop in — calls `process_new_item.py` per item |
+| `scripts/item_state.py` | Branch v4.0 verbatim | Drop in — adds `corrections[]` field for L1 |
+| `scripts/onboarding_queue.py` | Branch v4.0 verbatim | Drop in |
+| `scripts/audit_log.py` | **NEW** | Centralized writer for the three JSONL audit files + CLI subcommands |
+| `scripts/place_files.py` | Current main verbatim | Keep |
+| `scripts/remove_background.py` | Current main verbatim | Keep (already has response.text leak fix) |
+| `scripts/sync_to_whatnot.py` | Current main verbatim | Keep (already has literal-`\n` fix + Path.home() default) |
+| `references/*.md` | Current main (all 11) | Keep. Branch dropped 5; restore them all |
+| `CHANGELOG.md` | Current main + v6.0 entry | Append |
+| `ARCHITECTURE_AUDIT.md` | Current main (already has ARCHIVED banner) | No change |
+| `docs/plans/2026-05-13-v5-portability.md` | **MOVED from branch's `PRD.md`** | Repositioned as deferred future-work artifact, NOT a runtime skill file |
+
+**Deliberately discarded:** branch's `process_new_item.py` (842L
+rewrite). Re-applying main's 3 months of fixes onto it is more work
+than the inverse.
+
+**Deliberately removed in v6.0:** v3.7's `prompt()` and `confirm()`
+user-checkpoint patterns. Kept callable behind `--interactive` flag for
+backward compatibility; default path is autonomous.
+
+## Data flow — single item
+
+```
+photo intake → cluster detect (Mac only) → SKU allocate → state.json init
+   ↓
+phase_0: bg removal (autonomous)
+   ↓ [decision: model choice — best result by confidence]      → audit_log
+phase_1: appraisal (autonomous; needs Claude visual analysis)
+   ↓ [decisions: era, condition, price, shipping_eligible]     → audit_log
+phase_2: catalog draft (autonomous)
+   ↓ [decisions: type_category_id, tier_category_id]           → audit_log
+   ↓ [uses main's description_html + ROOM_BY_TYPE fixes]
+phase_3: inventory set
+   ↓
+phase_4: image upload (autonomous; subprocess square-image-upload)
+   ↓ FIRST IRREVERSIBLE WRITE to Square — corrections from here onward
+   ↓ matter more; audit_log captures with higher detail
+phase_5: payment link
+   ↓
+phase_6: label CSV row
+   ↓
+phase_7: GitHub Pages info card draft + push
+   ↓
+phase_8: Whatnot CSV row
+   ↓
+phase_9: Photos archive (Mac only; deferred in non-Mac env later via v5.0)
+   ↓
+state.status = "completed" → queue summary updated → user notified
+```
+
+**Failure on any phase:** item state → `BLOCKED`, queue updated with
+the question, batch continues with other items. Async question queue
+(v4.0 design preserved).
+
+## Audit trail schemas
+
+Four data artifacts, all written by `audit_log.py`. JSONL for streams;
+JSON for per-item state.
+
+### Per-item state — `items/RG-XXXX/.state.json`
+
+```json
+{
+  "sku": "RG-0042",
+  "status": "completed",
+  "source_image": "/Users/scottybe/Pictures/.../IMG_4231.heic",
+  "created_at": "2026-05-13T18:00:00Z",
+  "updated_at": "2026-05-13T18:04:22Z",
+  "created_in": "mac_cli",
+  "phases": {
+    "phase_0": {
+      "status": "completed",
+      "started_at": "...",
+      "completed_at": "...",
+      "duration_s": 12.3,
+      "outputs": {"hero_path": "...", "model_used": "removebg"}
+    },
+    "phase_1": {
+      "status": "completed",
+      "outputs": {
+        "title": "...",
+        "era": "...",
+        "price": 18.50,
+        "condition": "Very Good"
+      }
+    }
+  },
+  "decisions": [
+    {
+      "id": "dec-001",
+      "phase": "phase_1",
+      "type": "price",
+      "made_at": "2026-05-13T18:01:15Z",
+      "inputs_considered": {
+        "visible_condition": ["minor edge wear", "yellowing"],
+        "era": "1979",
+        "comparable_count_consulted": 5,
+        "comparable_price_range": [12, 28],
+        "lot_allocated_cost": 4.50
+      },
+      "choice": 18.50,
+      "alternatives_seen": [
+        {"value": 22.00, "rejected_reason": "above mid-range comps"},
+        {"value": 15.00, "rejected_reason": "under 4x markup"}
+      ],
+      "confidence": 0.78,
+      "rationale": "Mid-range comp anchor (~$20). Pulled to $18.50 on condition discount."
+    }
+  ],
+  "questions": [],
+  "review": {
+    "agent_finished_at": "2026-05-13T18:04:22Z",
+    "human_reviewed_at": null,
+    "elapsed_review_s": null,
+    "outcome": null
+  }
+}
+```
+
+`questions[]` carries the v4.0 async-question payloads (item parked, batch continues).
+
+### Decisions stream — `ops/inventory/decisions.jsonl`
+
+One line per autonomous decision, appended in real time. JSONL not
+JSON: append-only, no full-file rewrite, easy to `grep`/`jq`. This is
+the file L3 (deferred) will consume for pattern detection.
+
+```jsonl
+{"ts":"2026-05-13T18:01:15Z","sku":"RG-0042","phase":"phase_1","type":"price","choice":18.50,"confidence":0.78,...}
+{"ts":"2026-05-13T18:01:18Z","sku":"RG-0042","phase":"phase_1","type":"condition","choice":"Very Good","confidence":0.85,...}
+{"ts":"2026-05-13T18:02:01Z","sku":"RG-0042","phase":"phase_2","type":"type_category","choice":"CLZCJ62H4TTHDQ3ZBYMZQASQ","choice_name":"Books & Paper","confidence":0.95,...}
+```
+
+### Corrections stream — `ops/inventory/corrections.jsonl`
+
+Appended when you (or whoever reviews) edit anything the agent decided.
+Two write paths:
+
+- **Manual:** `audit_log.py correct --sku RG-0042 --decision dec-001 --new 22.00 --reason "underpriced for the condition"`
+- **Auto-detected:** when `process_new_item.py --review-mode` runs, it
+  diffs the current item state (label.json, Square catalog, GitHub
+  Pages card) against `decisions.jsonl` for that SKU and writes
+  corrections for anything that drifted.
+
+```jsonl
+{"ts":"2026-05-13T19:32:00Z","sku":"RG-0042","decision_id":"dec-001","decision_type":"price","agent_choice":18.50,"corrected_to":22.00,"correction_source":"manual","reason":"underpriced for the condition","reviewer":"scottybe"}
+{"ts":"2026-05-13T19:32:05Z","sku":"RG-0042","decision_id":"dec-007","decision_type":"shipping_eligible","agent_choice":true,"corrected_to":false,"correction_source":"auto-diff","reason":"label.json shippable=false","reviewer":"scottybe"}
+```
+
+This is the input to L3 (deferred). The data we collect now is what
+makes L3 worth building later.
+
+### Review timing stream — `ops/inventory/review_log.jsonl`
+
+L2 layer — answers "improve our time with those issues."
+
+```jsonl
+{"ts":"2026-05-13T19:32:00Z","sku":"RG-0042","event":"review_started"}
+{"ts":"2026-05-13T19:37:24Z","sku":"RG-0042","event":"review_completed","duration_s":324,"corrections_applied":2,"outcome":"accepted_with_corrections"}
+```
+
+Three terminal outcomes: `accepted_as_is`, `accepted_with_corrections`,
+`rejected_redo`.
+
+Over time, you get data like:
+
+- *"Books take 4min to review, ceramics take 11min"*
+- *"Pricing corrections account for 60% of review time on furniture"*
+- *"v3.7 phase-by-phase took avg 12min total per item; v6.0 autonomous + review takes avg 7min"*
+
+L2 doesn't analyze any of this. It just collects. The analysis tool
+(L3) reads them later.
+
+## Tooling enabled by audit data
+
+Without L3 yet, even L1+L2 give you:
+
+```
+audit_log.py report --sku RG-0042
+audit_log.py report --since 2026-05-01
+audit_log.py review-stats
+audit_log.py drift                      # decisions where agent's
+                                        # choice doesn't match current
+                                        # Square state — auto-correction
+                                        # candidates
+```
+
+## Size estimate
+
+`decisions.jsonl` accumulates ~8 decisions/item × ~30 items/month ≈ 240
+lines/month. ~30 KB/year. Not a concern. JSONL files live in
+`ops/inventory/` (private ops repo, not public items repo).
+
+## Migration — 3 PRs, not one
+
+| PR | Scope | Behavior change | Risk |
+|---|---|---|---|
+| **#1 — Infra only** | Land `item_state.py`, `onboarding_queue.py`, `audit_log.py` + the JSONL log initialization. `process_new_item.py` gains optional state-machine hooks but defaults to v3.7 interactive behavior. | None visible | Low — code paths added, not activated |
+| **#2 — Orchestrator + autonomous mode behind a flag** | Land `process_batch.py`. Add `--autonomous` flag to `process_new_item.py`. Run real items through it with the flag on to validate. SKILL.md still says "v3.7 interactive default" but documents the new mode. | Opt-in autonomous via flag | Medium — first real autonomous runs; mistakes captured in audit log + corrections |
+| **#3 — Flip the default** | SKILL.md bumps to v6.0, autonomous becomes default, audit-and-review flow becomes documented norm. `--interactive` kept as opt-out. | Default-on autonomous | High — de-risked by data from PR #2 |
+
+**Backward compatibility guarantees:**
+
+- Skill name stays `rg-full-auto` → cross-references in BRAND.md,
+  items/CLAUDE.md, brand design docs, Linear issues all keep working.
+- Existing items without `.state.json` → treated as "completed in
+  legacy mode." v6.0 never re-processes them.
+- Other skills that subprocess `process_new_item.py` → CLI surface
+  compatible. `--interactive` opt-out preserves v3.7 behavior.
+
+## Test strategy
+
+PRD §7 noted existing tests are broken
+(`test_rg_full_auto_catalog_fallback.py` references v3.x API). v6.0
+ships with a fresh test layer.
+
+| PR | Required tests (must pass before merge) |
+|---|---|
+| #1 (infra) | Unit: `item_state.py` state transitions; `onboarding_queue.py` queue add/remove/update; `audit_log.py` JSONL append atomicity (concurrent-write safety) |
+| #2 (orchestrator + flag) | Integration: `process_batch.py` on a fixture item (mocked Square API + mocked remove.bg). One real-item smoke run with `--autonomous` flag, hand-verified, audit-log inspected. |
+| #3 (default flip) | Regression diff: same input photo → v6.0 autonomous output vs v3.7 interactive output → compare Square catalog payload structurally. Differences must be intentional (e.g., `description_html` now, was `description` in v3.x). |
+
+**New test fixtures:**
+
+- `tests/fixtures/sample-photo.heic` — Photos-clustered candidate
+- `tests/fixtures/sample-label.json` — expected output shape
+- `tests/fixtures/sample-comps.json` — mock comparable sales data
+- Mock Square API responses for `batchInsertObjects`, inventory
+  `batchChange`, payment link create
+- Mock remove.bg API response
+
+**Deliberately not tested:**
+
+- Actual Square API calls (mock everything; no live test account writes)
+- Actual Photos.app integration (mock cluster detection output)
+- Visual correctness of generated HTML (Playwright UI tests in items/
+  repo already cover the rendered card)
+
+## Open questions / deferred
+
+- L3 pattern-detection layer — needs ≥30 items' correction data before
+  it'd produce useful patterns. Build after v6.0 has been live for
+  ~1 month.
+- The held branch's v5.0 portability PRD (`docs/plans/2026-05-13-v5-portability.md`)
+  — environment detection, capability matrix, deferred-action queue
+  for cross-environment phases. Next epic after v6.0 stabilizes.
+- Behavior on partially-completed items: should v6.0 detect that an
+  item has Square catalog entries but no `.state.json` and
+  reconstruct partial state? Or treat as completed-in-legacy-mode?
+  Lean toward legacy-mode, but worth confirming during PR #1.
+- Concurrency model: parallelism within a batch (multiple items
+  processed concurrently) is in the v4.0 design but not strictly
+  required for v6.0 ship. Could ship sequential first, parallel later.
+
+## Out of scope for v6.0
+
+- **v5.0 portability** — environment detection, capability matrix,
+  deferred-action queue. Lives in `docs/plans/2026-05-13-v5-portability.md`
+  as the next epic.
+- **Multi-machine batches** — running one batch across Mac + cloud +
+  cowork in parallel. Tied to v5.0.
+- **L3 pattern-detection feedback loop** — deferred until data exists.
+- **Visual aesthetic changes** to item cards — that's TVM-196's lane
+  (iridescent treatment); orthogonal to this work.
+
+## References
+
+- Held branch: `origin/claude/refactor-auto-onboarding-TyZdT` on
+  `richmondgeneral/skills`
+- Branch PRD (v5.0): being moved to
+  `rg-full-auto/docs/plans/2026-05-13-v5-portability.md`
+- Current v3.7 SKILL.md (the base for the rewrite)
+- BRAND.md (cross-references rg-full-auto for new-item workflow)
+- items/CLAUDE.md (documents the rg-full-auto workflow for the items
+  repo's perspective)


### PR DESCRIPTION
## Summary

Design synthesis from today's brainstorming session for **rg-full-auto v6.0** ("super full auto"). Combines current main v3.7 (with recent fixes) + branch `claude/refactor-auto-onboarding-TyZdT` v4.0 (batch + autonomous) + the branch's v5.0 PRD parked as deferred future-work.

## Files

| File | What |
|---|---|
| `rg-full-auto/docs/plans/2026-05-13-v6-super-full-auto-design.md` | The v6.0 design (351L) — section-confirmed through brainstorming |
| `rg-full-auto/docs/plans/2026-05-13-v5-portability-deferred.md` | The branch's original v5.0 PRD (560L) — repositioned as deferred future-work |

## Decisions taken

| Dimension | Choice |
|---|---|
| Autonomy | A — full autonomy, agent decides everything, user reviews post-onboard |
| Skill identity | Major version bump → v6.0 on existing `rg-full-auto/` path |
| Audit depth | L1 (passive structured log) + L2 (time-on-review). L3 deferred |

## Migration — 3 staged PRs after this design lands

1. Infra only (state machine, queue, audit_log) — no behavior change
2. Orchestrator + autonomous behind `--autonomous` flag — opt-in
3. Flip default — v6.0 ships, `--interactive` becomes the opt-out

## Branch policy

The branch `claude/refactor-auto-onboarding-TyZdT` is **preserved**. It is **not being merged as-is** — its `process_new_item.py` rewrite is 3 months stale and would lose recent fixes. The v4.0 verbatim files (`item_state.py`, `onboarding_queue.py`, `process_batch.py`) get lifted file-by-file in the staged PRs.

## Next

Transition to `writing-plans` skill for the detailed implementation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)